### PR TITLE
Fixed doors not unlocking and moving before locking

### DIFF
--- a/ShootingInteractions/EventsHandler.cs
+++ b/ShootingInteractions/EventsHandler.cs
@@ -195,10 +195,10 @@ namespace ShootingInteractions
 
                     // Unlock the door after the time indicated in the config (if greater than 0)
                     if (doorInteractionConfig.LockDuration > 0)
-                        Timing.CallDelayed(doorInteractionConfig.LockDuration, () => door.Lock(DoorLockReason.None, false));
+                        Timing.CallDelayed(doorInteractionConfig.LockDuration, () => door.Lock(DoorLockReason.Isolation, false));
 #endif
                     // Don't interact if bypass mode is disabled
-                    if (isBypassEnabled)
+                    if (!isBypassEnabled)
                         return true;
                 }
 
@@ -227,7 +227,7 @@ namespace ShootingInteractions
 
                         // Unlock the door after the time indicated in the config (if greater than 0)
                         if (doorInteractionConfig.LockDuration > 0)
-                            Timing.CallDelayed(doorInteractionConfig.LockDuration, () => door.Lock(DoorLockReason.None, false));
+                            Timing.CallDelayed(doorInteractionConfig.LockDuration, () => door.Lock(DoorLockReason.Isolation, false));
 #endif
                     });
 


### PR DESCRIPTION
Fixed the doors never being unlocked on the LabAPI version.
Fixed door moving before locking even with MoveBeforeLocking set to false, when bypass the player has no bypass